### PR TITLE
Handle case where engine returns null/undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ export default (engines) => ({
   load() {
     const state = {};
     const loads = engines.map(engine => engine.load().then((partialState => {
-      Object.entries(partialState).forEach(([key, value]) => {
+      Object.entries(partialState || {}).forEach(([key, value]) => {
         if (process.env.NODE_ENV !== 'production') {
           if (state[key]) {
             console.warn( // eslint-disable-line no-console

--- a/test/index.js
+++ b/test/index.js
@@ -63,6 +63,20 @@ describe('index', () => {
       return expect(engine.load()).to.become({ foo: 1, bar: 2 });
     });
 
+    it('should handle an engine returning falsy values', () => {
+      // given
+      const state0 = { foo: 1 };
+      const engine0 = { load: sinon.stub().resolves(state0) };
+
+      const state1 = null;
+      const engine1 = { load: sinon.stub().resolves(state1) };
+
+      const engine = engines([engine0, engine1]);
+
+      // expect
+      return expect(engine.load()).to.become({ foo: 1 });
+    });
+
     it('should pass error from decorated engine', () => {
       // given
       const state0 = { foo: 1 };


### PR DESCRIPTION
`Object.entries` will throw an error in this case.
