### PR TITLE
Add missing dependency on 'babel-runtime'

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,7 @@
     "sinon-as-promised": "^4.0.0",
     "sinon-chai": "^2.8.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "babel-runtime": "^6.22.0"
+  }
 }


### PR DESCRIPTION
Add an explicit dependency on `babel-runtime` since the code generated by babel includes imports like this: 

```
'use strict';

Object.defineProperty(exports, "__esModule", {
  value: true
});

var _promise = require('babel-runtime/core-js/promise');

// ...
```

I noticed this while trying to migrate a large project which consumes this library to PNPM, which is much stricter about undeclared dependencies. I assume that Yarn v2 would have the same problem. 